### PR TITLE
fix(GaugeChart): min/max spacing

### DIFF
--- a/packages/core/src/components/graphs/gauge.ts
+++ b/packages/core/src/components/graphs/gauge.ts
@@ -393,10 +393,7 @@ export class Gauge extends Component {
 
 		const numbersGroup = DOMUtils.appendOrSelect(svg, "g.guage-min-max");
 
-		const minGroup = DOMUtils.appendOrSelect(
-			numbersGroup,
-			"g.gauge-min"
-		);
+		const minGroup = DOMUtils.appendOrSelect(numbersGroup, "g.gauge-min");
 
 		const minNumber = DOMUtils.appendOrSelect(
 			minGroup,
@@ -412,13 +409,13 @@ export class Gauge extends Component {
 			.attr("text-anchor", "middle")
 			.style("font-size", `${minMaxFontSize(radius) / 1.5}px`)
 			.text((d) => `${numberFormatter(d)}`)
-			.attr("x", -innerRadius + arcWidth + (minNumber.node().getBBox().width/2))
+			.attr(
+				"x",
+				-innerRadius + arcWidth + minNumber.node().getBBox().width / 2
+			)
 			.attr("y", 0);
 
-		const maxGroup = DOMUtils.appendOrSelect(
-			numbersGroup,
-			"g.gauge-max"
-		);
+		const maxGroup = DOMUtils.appendOrSelect(numbersGroup, "g.gauge-max");
 
 		const maxNumber = DOMUtils.appendOrSelect(
 			maxGroup,
@@ -434,7 +431,10 @@ export class Gauge extends Component {
 			.attr("text-anchor", "middle")
 			.style("font-size", `${minMaxFontSize(radius) / 1.5}px`)
 			.text((d) => `${numberFormatter(d)}`)
-			.attr("x", innerRadius - arcWidth - (maxNumber.node().getBBox().width/2))
+			.attr(
+				"x",
+				innerRadius - arcWidth - maxNumber.node().getBBox().width / 2
+			)
 			.attr("y", 0);
 	}
 

--- a/packages/core/src/components/graphs/gauge.ts
+++ b/packages/core/src/components/graphs/gauge.ts
@@ -374,7 +374,8 @@ export class Gauge extends Component {
 	drawMinMax() {
 		const svg = this.getContainerSVG();
 		const radius = this.computeRadius();
-
+		const innerRadius = this.getInnerRadius();
+		const arcWidth = radius - innerRadius;
 		const options = this.model.getOptions();
 		const min = Tools.getProperty(options, "min");
 		const max = Tools.getProperty(options, "max");
@@ -395,7 +396,7 @@ export class Gauge extends Component {
 		const minGroup = DOMUtils.appendOrSelect(
 			numbersGroup,
 			"g.gauge-min"
-		).attr("transform", `translate(-150, 0)`);
+		);
 
 		const minNumber = DOMUtils.appendOrSelect(
 			minGroup,
@@ -410,12 +411,14 @@ export class Gauge extends Component {
 			.merge(minNumber)
 			.attr("text-anchor", "middle")
 			.style("font-size", `${minMaxFontSize(radius) / 1.5}px`)
-			.text((d) => `${numberFormatter(d)}`);
+			.text((d) => `${numberFormatter(d)}`)
+			.attr("x", -innerRadius + arcWidth + (minNumber.node().getBBox().width/2))
+			.attr("y", 0);
 
 		const maxGroup = DOMUtils.appendOrSelect(
 			numbersGroup,
 			"g.gauge-max"
-		).attr("transform", `translate(150, 0)`);
+		);
 
 		const maxNumber = DOMUtils.appendOrSelect(
 			maxGroup,
@@ -430,7 +433,9 @@ export class Gauge extends Component {
 			.merge(maxNumber)
 			.attr("text-anchor", "middle")
 			.style("font-size", `${minMaxFontSize(radius) / 1.5}px`)
-			.text((d) => `${numberFormatter(d)}`);
+			.text((d) => `${numberFormatter(d)}`)
+			.attr("x", innerRadius - arcWidth - (maxNumber.node().getBBox().width/2))
+			.attr("y", 0);
 	}
 
 	mapSubranges(array) {
@@ -482,7 +487,10 @@ export class Gauge extends Component {
 			.endAngle(function (d: any) {
 				return d.end;
 			});
-
+		console.log("INNER RADIUS");
+		console.log(innerRadius);
+		console.log("OUTER RADIUS");
+		console.log(radius);
 		const subRangeGroup = DOMUtils.appendOrSelect(svg, "g.subrange-group");
 
 		const subRange = subRangeGroup


### PR DESCRIPTION
### Updates
- changed the way spacing was calculated so that min and max maintain their position relative to the arc

### Demo screenshot or recording

### Review checklist (for reviewers only)
- [ ] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide](https://github.com/carbon-design-system/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)
