### PR TITLE
feat(MeterChart): value color options

### DIFF
--- a/packages/core/demo/data/meter.ts
+++ b/packages/core/demo/data/meter.ts
@@ -23,6 +23,12 @@ export const meterOptionsWithStatus = {
 export const meterOptionsCustomColor = {
 	title: "Meter Chart - statuses and custom color",
 	meter: {
+		statusBar: {
+			percentageIndicator: {
+				useStatusColor: true,
+				useValueColor: true
+			}
+		},
 		peak: 70,
 		status: {
 			ranges: [
@@ -53,7 +59,8 @@ export const meterOptionsSubranges = {
 	meter: {
 		statusBar: {
 			percentageIndicator: {
-				removePercentage: true
+				removePercentage: true,
+				useValueColor: true
 			}
 		},
 		min: 0,

--- a/packages/core/src/components/essentials/title-meter.ts
+++ b/packages/core/src/components/essentials/title-meter.ts
@@ -32,6 +32,29 @@ export class MeterTitle extends Title {
 
 		// appends the associated percentage after title
 		this.appendPercentage();
+		const useValueColor = Tools.getProperty(
+			options,
+			"meter",
+			"statusBar",
+			"percentageIndicator",
+			"useValueColor"
+		);
+		const useStatusColor = Tools.getProperty(
+			options,
+			"meter",
+			"statusBar",
+			"percentageIndicator",
+			"useStatusColor"
+		);
+		if (useValueColor && useStatusColor != true) {
+			const percentage = DOMUtils.appendOrSelect(
+				svg,
+				"text.percent-value"
+			);
+			percentage.style("fill", () => {
+				return this.model.getFillColor(dataset[groupMapsTo]);
+			});
+		}
 
 		// if status ranges are provided (custom or default), display indicator
 		this.displayStatus();
@@ -108,6 +131,16 @@ export class MeterTitle extends Title {
 	 * Appends the associated percentage to the end of the title
 	 */
 	appendPercentage() {
+		const options = this.model.getOptions();
+		const status = this.model.getStatus();
+		const userProvidedScale = Tools.getProperty(options, "color", "scale");
+		const useStatusColor = Tools.getProperty(
+			options,
+			"meter",
+			"statusBar",
+			"percentageIndicator",
+			"useStatusColor"
+		);
 		const dataValue = this.model.getDisplayData().value;
 
 		// use the title's position to append the percentage to the end
@@ -147,6 +180,13 @@ export class MeterTitle extends Title {
 			.text((d) => {
 				return `${d}` + (removePercentSymbol ? `` : `%`);
 			})
+			.attr(
+				"class",
+				useStatusColor === true &&
+					(status != null || !userProvidedScale)
+					? `percent-value ${status}`
+					: "percent-value"
+			)
 			.attr(
 				"x",
 				+title.attr("x") + title.node().getComputedTextLength() + offset

--- a/packages/core/src/styles/components/_meter-title.scss
+++ b/packages/core/src/styles/components/_meter-title.scss
@@ -2,6 +2,15 @@
 	text.meter-title,
 	text.percent-value {
 		fill: $text-01;
+		&.danger {
+			fill: $support-01;
+		}
+		&.warning {
+			fill: $support-03;
+		}
+		&.success {
+			fill: $support-02;
+		}
 	}
 
 	g.status-indicator {


### PR DESCRIPTION
### Updates
- added useValueColor which allows the value bar color to be used on the percentage text
- added useStatusColor which essentially does the same as above, only based on status

### Demo screenshot or recording

### Review checklist (for reviewers only)
- [ ] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide](https://github.com/carbon-design-system/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)
