### PR TITLE
fix(MeterChart): percentage text size increased

### DIFF
--- a/packages/core/demo/data/meter.ts
+++ b/packages/core/demo/data/meter.ts
@@ -53,8 +53,7 @@ export const meterOptionsSubranges = {
 	meter: {
 		statusBar: {
 			percentageIndicator: {
-				removePercentage: true,
-				fontSize: "24px"
+				removePercentage: true
 			}
 		},
 		min: 0,

--- a/packages/core/demo/data/meter.ts
+++ b/packages/core/demo/data/meter.ts
@@ -53,7 +53,8 @@ export const meterOptionsSubranges = {
 	meter: {
 		statusBar: {
 			percentageIndicator: {
-				removePercentage: true
+				removePercentage: true,
+				fontSize: "24px"
 			}
 		},
 		min: 0,

--- a/packages/core/src/components/essentials/title-meter.ts
+++ b/packages/core/src/components/essentials/title-meter.ts
@@ -14,6 +14,8 @@ export class MeterTitle extends Title {
 		const svg = this.getContainerSVG();
 		const { groupMapsTo } = options.data;
 
+		const valueFontSize = parseFloat(getComputedStyle(DOMUtils.appendOrSelect(svg, "text.percent-value").node()).fontSize).toString().replace(/[^0-9]/g, '');
+			
 		// the title for a meter, is the label for that dataset
 		const title = svg
 			.selectAll("text.meter-title")
@@ -32,6 +34,8 @@ export class MeterTitle extends Title {
 
 		// appends the associated percentage after title
 		this.appendPercentage();
+
+		title.attr("y", valueFontSize)
 
 		// if status ranges are provided (custom or default), display indicator
 		this.displayStatus();
@@ -121,6 +125,14 @@ export class MeterTitle extends Title {
 			"removePercentage"
 		);
 
+		const valueFontSize = Tools.getProperty(
+			this.model.getOptions(),
+			"meter",
+			"statusBar",
+			"percentageIndicator",
+			"fontSize"
+		);
+
 		// check if it is enabled
 		const data =
 			Tools.getProperty(
@@ -147,6 +159,7 @@ export class MeterTitle extends Title {
 			.text((d) => {
 				return `${d}` + (removePercentSymbol ? `` : `%`);
 			})
+			.style("font-size", valueFontSize)
 			.attr(
 				"x",
 				+title.attr("x") + title.node().getComputedTextLength() + offset

--- a/packages/core/src/components/essentials/title-meter.ts
+++ b/packages/core/src/components/essentials/title-meter.ts
@@ -14,8 +14,14 @@ export class MeterTitle extends Title {
 		const svg = this.getContainerSVG();
 		const { groupMapsTo } = options.data;
 
-		const valueFontSize = parseFloat(getComputedStyle(DOMUtils.appendOrSelect(svg, "text.percent-value").node()).fontSize).toString().replace(/[^0-9]/g, '');
-			
+		const valueFontSize = parseFloat(
+			getComputedStyle(
+				DOMUtils.appendOrSelect(svg, "text.percent-value").node()
+			).fontSize
+		)
+			.toString()
+			.replace(/[^0-9]/g, "");
+
 		// the title for a meter, is the label for that dataset
 		const title = svg
 			.selectAll("text.meter-title")
@@ -35,7 +41,7 @@ export class MeterTitle extends Title {
 		// appends the associated percentage after title
 		this.appendPercentage();
 
-		title.attr("y", valueFontSize)
+		title.attr("y", valueFontSize);
 
 		// if status ranges are provided (custom or default), display indicator
 		this.displayStatus();

--- a/packages/core/src/configuration.ts
+++ b/packages/core/src/configuration.ts
@@ -340,7 +340,7 @@ const meterChart: MeterChartOptions = Tools.merge({}, chart, {
 			percentageIndicator: {
 				enabled: true,
 				removePercentage: false,
-				fontSize: "16px"
+				fontSize: "32px"
 			}
 		}
 	}

--- a/packages/core/src/configuration.ts
+++ b/packages/core/src/configuration.ts
@@ -339,7 +339,8 @@ const meterChart: MeterChartOptions = Tools.merge({}, chart, {
 		statusBar: {
 			percentageIndicator: {
 				enabled: true,
-				removePercentage: false
+				removePercentage: false,
+				fontSize: "16px"
 			}
 		}
 	}


### PR DESCRIPTION
### Updates
- adds valueFontSize options which allows fine tuning of percentage text size
- default font size increased for percentage text

### Demo screenshot or recording

### Review checklist (for reviewers only)
- [ ] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide](https://github.com/carbon-design-system/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)
