### PR TITLE
fix(MeterChart): adjusted subrange width

### DIFF
--- a/packages/core/src/components/graphs/meter.ts
+++ b/packages/core/src/components/graphs/meter.ts
@@ -172,8 +172,8 @@ export class Meter extends Component {
 			.classed("subrange", true)
 			.merge(subrange)
 			.attr("x", (d) => xScale(d.begin))
-			.attr("y", 5)
-			.attr("height", Tools.getProperty(options, "meter", "height") + 5)
+			.attr("y", -5)
+			.attr("height", Tools.getProperty(options, "meter", "height") + 10)
 			.attr("width", (d) =>
 				maximumBarWidth ? xScale(100) : xScale(d.end - d.begin)
 			)


### PR DESCRIPTION
### Updates
- adjusted positioning and width of subrange to be the same as it is in gauge

### Demo screenshot or recording

### Review checklist (for reviewers only)
- [ ] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [ ] Meets the [code style guide](https://github.com/carbon-design-system/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)
